### PR TITLE
Refactor data package initialization to use lazy imports

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,15 +1,16 @@
 """Data module for AI Trading Bot."""
 
-from .fetchers import HistoricalDataFetcher, LiveDataFetcher
-from .indicators import TechnicalIndicators
-from .preprocessing import FeatureEngineer
-from .simulator import MarketSimulator, SimulatedMarketData
+from importlib import import_module
+from typing import Any, Dict, List
 
-# Compatibility import (deprecated - use core.constants instead)
-try:
-    from . import constants  # type: ignore
-except ImportError:  # pragma: no cover
-    constants = None
+_ATTR_TO_MODULE: Dict[str, str] = {
+    "HistoricalDataFetcher": ".fetchers",
+    "LiveDataFetcher": ".fetchers",
+    "TechnicalIndicators": ".indicators",
+    "FeatureEngineer": ".preprocessing",
+    "MarketSimulator": ".simulator",
+    "SimulatedMarketData": ".simulator",
+}
 
 __all__ = [
     "HistoricalDataFetcher",
@@ -18,4 +19,21 @@ __all__ = [
     "FeatureEngineer",
     "MarketSimulator",
     "SimulatedMarketData",
+    "constants",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "constants":
+        return import_module(".constants", __name__)
+
+    try:
+        module = import_module(_ATTR_TO_MODULE[name], __name__)
+    except KeyError as exc:  # pragma: no cover - defensive programming
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    return getattr(module, name)
+
+
+def __dir__() -> List[str]:
+    return sorted(set(__all__ + list(globals().keys())))


### PR DESCRIPTION
## Summary
- resolve the `data.__init__` merge conflict by restoring the lazy import table and helpers
- expose the extended `__all__` without eager submodule imports to avoid import cycles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63c3a412083228e70ee570a29a4de